### PR TITLE
Buxfixes for compiling with rtems-source-builder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,7 +86,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   echo -e "net.ipv6.conf.all.disable_ipv6 = 1\nnet.ipv6.conf.default.disable_ipv6 = 1\nnet.ipv6.conf.lo.disable_ipv6 = 1\n" >> /etc/sysctl.conf
   sysctl -p
   apt-get update -y
-  apt-get install -y python-pip build-essential python-dev libffi-dev git bison cvs g++ flex python-dev zlib1g-dev libncurses-dev  unzip
+  apt-get install -y python-pip build-essential python-dev libffi-dev git bison cvs g++ flex python-dev zlib1g-dev libncurses-dev  unzip automake autoconf
   cd /tmp
   wget http://ftp.gnu.org/gnu/texinfo/texinfo-4.13.tar.gz
   gzip -dc < texinfo-4.13.tar.gz | tar -xf -
@@ -99,7 +99,7 @@ SCRIPT
 
   $nonrootscript = <<SCRIPT
   git clone https://github.com/jeffmurphy/rtems-source-builder.git
-  mkdir -p ~/development/rtems/4.11
+  mkdir -p ~/development/rtems/4.10
   cd rtems-source-builder/rtems
   ../source-builder/sb-set-builder --log=l-sparc.txt --prefix=$HOME/development/rtems/4.10 --with-rtems 4.10/rtems-sparc
   cd $HOME


### PR DESCRIPTION
The automake and autoconf packages must be installed. Also, in order to
compile rtems-source-builder with version 4.10, the 4.10 directory must
be created, rather than the 4.11 directory.
